### PR TITLE
[DOESN'T WORK] Fix totem ID; fix totem bar vanishing for a shaman

### DIFF
--- a/EventHorizon/EventHorizon.lua
+++ b/EventHorizon/EventHorizon.lua
@@ -1582,12 +1582,13 @@ end
 local SpellFrame_PLAYER_TOTEM_UPDATE = function ( self, slot )
 
     if not ( self.totem ) then return end
-    local tUp, tName, tStart, tDuration, tIcon = GetTotemInfo( slot )
-    if not tUp or tName ~= GetSpellInfo( self.totem ) then return end
+    local tUp, tName, tStart, tDuration, tIcon, tModRate, tSpellID = GetTotemInfo(slot)
+    if not tUp or tSpellID ~= self.totem then return end
 
     local now = GetTime()
 
-    local name, icon, count, duration, expirationTime, source, spellID = tName, tIcon, 1, tDuration, tStart + tDuration, "player", tID
+    local name, icon, count, duration, expirationTime, source, spellID = tName, tIcon, 1, tDuration, tStart + tDuration,
+      "player", tSpellID
     local addnew
 
     if name then
@@ -2895,6 +2896,12 @@ local mainframe_UPDATE_SHAPESHIFT_FORM = function (self)
     end
   else
     mainframe:Hide()
+  end
+
+  if class == "SHAMAN" then
+    for i = 1, MAX_TOTEMS do
+      mainframe:PLAYER_TOTEM_UPDATE(i)
+    end
   end
 
   return true


### PR DESCRIPTION
The name-based totem recognition logic failed in some cases where the entity summoned didn't match the name of a spell (for example, spell Fire Elemental summons a Greater Fire Elemental). This PR fixes it by switching to totem IDs.
The caveat is - totem IDs sometimes differ from the ID of a spell in a spellbook; you need to get the correct ID of a totem via a macro like:
```
/run print(GetTotemInfo(1))
/run print(GetTotemInfo(2))
/run print(GetTotemInfo(3))
/run print(GetTotemInfo(4))
```
, the ID of a totem will be in the last column.

Also, this PR fixes a problem of totems vanishing for a shaman when you go in a ghost wolf form and back - "fixes" via brute force, I couldn't find a way to do this gracefully.